### PR TITLE
fixed delete request, added calls for getting all user/task assignments

### DIFF
--- a/src/Harvest.js
+++ b/src/Harvest.js
@@ -115,6 +115,14 @@ module.exports = class Harvest {
     return wrapper
   }
 
+  get task_assignments() {
+    return this._getWrapper('task_assignments')
+  }
+
+  get user_assignments() {
+    return this._getWrapper('user_assignments')
+  }
+
   _getWrapper(name) {
     if (!this.wrappers[name]) {
       this.wrappers[name] = new Wrapper(this.url, name, {

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -207,13 +207,14 @@ module.exports = class Wrapper {
     })
   }
 
-  async _make_delete_request(endpoint) {
+  async _make_delete_request(endpoint, args = {}) {
+    args = Object.assign({}, args, this.headers)
     if (this.pipe_path.length) {
       endpoint = this.pipe_path + '/' + endpoint
     }
 
     return new Promise((resolve, reject) => {
-      this.rest_client.delete(this.base_url + endpoint, (data, response) => {
+      this.rest_client.delete(this.base_url + endpoint, args, (data, response) => {
         resolve(data)
       })
     })


### PR DESCRIPTION
First of all, thanks for developing this!

I've noticed, that the delete requests weren't working properly due to the missing `args` argument, which all the HTTP methods seem to require.

Also I've added the functions to call the `task_assignments` and `user_assignments` endpoints directly without the need to use the pipe on `projects`.